### PR TITLE
[Doc] Add CSAT and Ray Assistant widgets

### DIFF
--- a/doc/source/_static/css/assistant.css
+++ b/doc/source/_static/css/assistant.css
@@ -1,0 +1,136 @@
+/* Kapa Ask AI button */
+#kapa-widget-container figure {
+    padding: 0 !important;
+  }
+
+  .mantine-Modal-root figure {
+    padding: 0 !important;
+  }
+
+.container-xl.blurred {
+    filter: blur(5px);
+}
+
+.chat-widget {
+    position: fixed;
+    bottom: 10px;
+    right: 10px;
+    z-index: 1000;
+}
+
+.chat-popup {
+  display: none;
+  position: fixed;
+  top: 20%;
+  left: 50%;
+  transform: translate(-50%, -20%);
+  width: 50%;
+  height: 70%;
+  background-color: var(--pst-color-surface);
+  border: 1px solid var(--pst-color-border);
+  border-radius: 10px;
+  box-shadow: 0 5px 10px var(--pst-color-shadow);
+  z-index: 1032;
+  max-height: 1000px;
+  overflow: hidden;
+  padding-bottom: 40px;
+}
+
+.chatFooter {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 100%;
+    background-color: var(--pst-color-surface);
+}
+
+#openChatBtn {
+    background-color: var(--pst-color-on-background);
+    color: var(--pst-color-text-base);
+    width: 70px;
+    height: 70px;
+    border-radius: 10px;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#closeChatBtn {
+    border: none;
+    background-color: transparent;
+    color: var(--pst-color-text-base);
+    font-size: 1.2em;
+}
+
+#closeChatBtn:hover {
+    color: var(--pst-color-link-hover);
+}
+
+#searchBar {
+  border: 1px solid var(--pst-color-border);
+  background-color: var(--pst-color-on-surface);
+}
+
+.chatHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: .5rem;
+}
+
+.chatHeader > .header-wrapper {
+  text-align: center;
+  width: 100%;
+}
+
+.chatContentContainer {
+    padding: 15px;
+    max-height: calc(100% - 80px);
+    overflow-y: auto;
+}
+
+.chatContentContainer input {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+#result{
+  padding: 15px;
+  border-radius: 10px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  background-color: var(--pst-color-on-surface);
+  max-height: calc(100% - 20px);
+  overflow-y: auto;
+}
+
+.chatContentContainer textarea {
+  flex-grow: 1;
+  min-width: 50px;
+  max-height: 40px;
+  resize: none;
+}
+
+.searchBtn {
+    white-space: nowrap;
+}
+
+.input-group {
+    display: flex;
+    align-items: stretch;
+}
+
+#blurDiv {
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  backdrop-filter: blur(5px);
+  z-index: 1031;
+}
+
+#blurDiv.blurDiv-hidden {
+  display: none !important;
+}

--- a/doc/source/_static/css/csat.css
+++ b/doc/source/_static/css/csat.css
@@ -1,0 +1,77 @@
+/* CSAT widgets */
+#csat-inputs {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.csat-hidden {
+  display: none !important;
+}
+
+#csat-feedback-label {
+  color: var(--pst-color-text-base);
+  font-weight: 500;
+}
+
+.csat-button {
+  margin-left: 16px;
+  padding: 8px 16px 8px 16px;
+  border-radius: 4px;
+  border: 1px solid var(--pst-color-border);
+  background: var(--pst-color-background);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  width: 85px;
+}
+
+#csat-textarea-group {
+  display: flex;
+  flex-direction: column;
+}
+
+#csat-submit {
+  margin-left: auto;
+  font-weight: 700;
+  border: none;
+  margin-top: 12px;
+  cursor: pointer;
+}
+
+#csat-feedback-received {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+.csat-button-active {
+  border: 1px solid var(--pst-color-border);
+}
+
+.csat-icon {
+  margin-right: 4px;
+}
+
+#csat {
+  padding: 1em;
+  min-width: 60%;
+}
+
+#csat-textarea {
+  resize: none;
+  background-color: var(--pst-color-on-background);
+  border: 1px solid var(--pst-color-border);
+  border-radius: 4px;
+}
+
+#csat-textarea::placeholder {
+  color: var(--pst-color-text-base);
+}
+
+.csat-icon > path {
+  fill: var(--pst-color-text-base);
+}

--- a/doc/source/_static/js/assistant.js
+++ b/doc/source/_static/js/assistant.js
@@ -11,40 +11,44 @@ var chatPopupDiv = document.createElement("div");
 chatPopupDiv.className = "chat-popup";
 chatPopupDiv.id = "chatPopup";
 chatPopupDiv.innerHTML = `
-    <div class="chatHeader bg-light p-2 d-flex justify-content-between align-items-center">
-        <div style="width: 30px;"></div>
-        <div class="text-center w-100">
-            <b>Ray Docs AI - Ask a question</b>
-        </div>
-        <button id="closeChatBtn" class="btn">
-            <i class="fas fa-times"></i>
-        </button>
+  <div class="chatHeader">
+    <div class="header-wrapper">
+      <h3>Ray Docs AI - Ask a question</h3>
     </div>
-    <div class="chatContentContainer">
-        <div class="input-group">
-            <textarea id="searchBar" class="input" rows="3" placeholder="Do not include any personal or confidential information."></textarea>
-            <div class="input-group-append">
-                <button id="searchBtn" class="btn btn-primary">Ask AI</button>
-            </div>
-        </div>
-        <div id="result"></div>
+    <button id="closeChatBtn" class="btn">
+      <i class="fas fa-times"></i>
+    </button>
+  </div>
+  <div class="chatContentContainer">
+    <div class="input-group">
+      <textarea id="searchBar" class="input" rows="3" placeholder="Do not include any personal or confidential information."></textarea>
+      <div class="input-group-append">
+        <button id="searchBtn" class="btn btn-primary">Ask AI</button>
+      </div>
     </div>
-    <div class="chatFooter text-right p-2">
-        © Copyright 2023, The Ray Team.
-    </div>
+    <div id="result"></div>
+  </div>
+  <div class="chatFooter text-right p-2">
+    © Copyright 2023, The Ray Team.
+  </div>
 `
 document.body.appendChild(chatPopupDiv);
 
+const blurDiv = document.createElement('div')
+blurDiv.id = "blurDiv"
+blurDiv.classList.add("blurDiv-hidden")
+document.body.appendChild(blurDiv);
+
 // blur background when chat popup is open
 document.getElementById('openChatBtn').addEventListener('click', function() {
-    document.getElementById('chatPopup').style.display = 'block';
-    document.querySelector('.container-xl').classList.add('blurred');
+  document.getElementById('chatPopup').style.display = 'block';
+  blurDiv.classList.remove("blurDiv-hidden");
 });
 
 // un-blur background when chat popup is closed
 document.getElementById('closeChatBtn').addEventListener('click', function() {
-    document.getElementById('chatPopup').style.display = 'none';
-    document.querySelector('.container-xl').classList.remove('blurred');
+  document.getElementById('chatPopup').style.display = 'none';
+  blurDiv.classList.add("blurDiv-hidden");
 });
 
 // set code highlighting options

--- a/doc/source/_templates/csat.html
+++ b/doc/source/_templates/csat.html
@@ -6,13 +6,13 @@
     <span>Was this helpful?</span>
     <div id="csat-yes" class="csat-button">
       <svg id="csat-yes-icon" class="csat-hidden csat-icon" width="18" height="13" viewBox="0 0 18 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M7.00023 10.172L16.1922 0.979004L17.6072 2.393L7.00023 13L0.63623 6.636L2.05023 5.222L7.00023 10.172Z" fill="black"/>
+        <path d="M7.00023 10.172L16.1922 0.979004L17.6072 2.393L7.00023 13L0.63623 6.636L2.05023 5.222L7.00023 10.172Z" />
       </svg>
       <span>Yes<span>
     </div>
     <div id="csat-no" class="csat-button">
       <svg id="csat-no-icon" class="csat-hidden csat-icon" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M7.00023 5.58599L11.9502 0.635986L13.3642 2.04999L8.41423 6.99999L13.3642 11.95L11.9502 13.364L7.00023 8.41399L2.05023 13.364L0.63623 11.95L5.58623 6.99999L0.63623 2.04999L2.05023 0.635986L7.00023 5.58599Z" fill="black"/>
+        <path d="M7.00023 5.58599L11.9502 0.635986L13.3642 2.04999L8.41423 6.99999L13.3642 11.95L11.9502 13.364L7.00023 8.41399L2.05023 13.364L0.63623 11.95L5.58623 6.99999L0.63623 2.04999L2.05023 0.635986L7.00023 5.58599Z" />
       </svg>
       <span>No<span>
     </div>


### PR DESCRIPTION
## Why are these changes needed?

This PR adds in the AI Assistant and CSAT widgets.

- The background blur when opening the AI Assistant was rewritten; styles were not being applied correctly when opening the assistant. It's better to have a div dedicated for this which overlays everything except the modal rather than using a selector on a background element.
- Styles have been adjusted to work with both dark and light themes.

## Related issue number

Partially addresses https://github.com/ray-project/ray/issues/37944.
Depends on https://github.com/peytondmurray/ray/pull/2.
PR 5/x targeting https://github.com/ray-project/ray/pull/41115.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
