### PR TITLE
[Doc] Optimize build time

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,7 +19,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sou
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext show
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -202,3 +202,6 @@ pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
+
+show:
+	python -m http.server -d _build/html/

--- a/doc/source/_static/js/custom.js
+++ b/doc/source/_static/js/custom.js
@@ -24,9 +24,44 @@ function loadVisibleTermynals() {
     });
 }
 
-window.addEventListener("scroll", loadVisibleTermynals);
-createTermynals();
-loadVisibleTermynals();
+// Store the state of the page in the browser's local storage.
+// This includes the sidebar dropdown menus which have been opened, and the
+// sidebar scroll position.
+function handleState() {
+  const sidebar = document.getElementById("main-sidebar")
+
+  window.addEventListener("beforeunload", () => {
+    if (sidebar) {
+      // Save opened checkboxes
+      localStorage.setItem("checkboxes",
+        JSON.stringify(
+          Array.from(
+            sidebar.querySelectorAll("input[type=checkbox]")
+          ).filter(input => input.checked).map(input => input.id)
+        )
+      )
+
+      // Save scroll postion
+      localStorage.setItem("scroll", sidebar.scrollTop)
+    }
+  })
+
+  const storedCheckboxes = localStorage.getItem("checkboxes")
+  if (storedCheckboxes) {
+    JSON.parse(storedCheckboxes).forEach(id => {
+      document.getElementById(id).checked = true
+    })
+  }
+
+  const storedScrollPosition = localStorage.getItem("scroll")
+  if (storedScrollPosition) {
+    if (sidebar) {
+      sidebar.scrollTop = storedScrollPosition;
+    }
+    localStorage.removeItem("scroll");
+  }
+
+}
 
 // Send GA events any time a code block is copied
 document.addEventListener("DOMContentLoaded", function() {
@@ -57,3 +92,8 @@ document.addEventListener("DOMContentLoaded", function() {
     window.open('https://www.anyscale.com', '_blank');
   }
 });
+
+window.addEventListener("scroll", loadVisibleTermynals);
+createTermynals();
+loadVisibleTermynals();
+handleState()

--- a/doc/source/_templates/main-sidebar.html
+++ b/doc/source/_templates/main-sidebar.html
@@ -1,11 +1,3 @@
-{%- set sidebar_nav_html = generate_toctree_html("sidebar",
-startdepth=0,
-show_nav_level=0,
-maxdepth=theme_navigation_depth|int,
-collapse=theme_collapse_navigation|tobool,
-includehidden=True,
-titles_only=True)
--%}
-<nav class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
-  <div class="bd-toc-item navbar-nav">{{ sidebar_nav_html }}</div>
+<nav id="main-sidebar" class="bd-docs-nav bd-links" aria-label="{{ _('Section Navigation') }}">
+  <div class="bd-toc-item navbar-nav">{{ cached_toctree }}</div>
 </nav>

--- a/doc/source/serve/advanced-guides/index.md
+++ b/doc/source/serve/advanced-guides/index.md
@@ -11,7 +11,6 @@ dyn-req-batch
 inplace-updates
 dev-workflow
 grpc-guide
-deployment-graphs
 managing-java-deployments
 deploy-vm
 ```


### PR DESCRIPTION
## Why are these changes needed?

This PR optimizes the build time of the `docs-build-system-upgrade` branch.

It does this by generating the sidebar HTML once (per worker) and then reusing it on every page, bypassing `pydata-sphinx-theme`'s sidebar construction machinery. To maintain the collapsed/expanded state of the sidebar dropdown items, we use the browser's local storage, which is restored on each page load.

- Moves the custom directives in `conf.py` into `custom_directives.py` at the request of @maxpumperla
- Removes reference to document that doesn't exist
- Add `make show` command, which used `http.server` to serve docs built locally
- Removes code for making "galleries", which we aren't using in the new docs build system

## Related issue number

Partially addresses https://github.com/ray-project/ray/issues/37944.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
