### PR TITLE
[Doc] Fix cached toctree behavior

### DIFF
--- a/doc/source/_static/js/custom.js
+++ b/doc/source/_static/js/custom.js
@@ -25,33 +25,15 @@ function loadVisibleTermynals() {
 }
 
 // Store the state of the page in the browser's local storage.
-// This includes the sidebar dropdown menus which have been opened, and the
-// sidebar scroll position.
-function handleState() {
+// For now this includes just the sidebar scroll position.
+document.addEventListener("DOMContentLoaded", () => {
   const sidebar = document.getElementById("main-sidebar")
 
   window.addEventListener("beforeunload", () => {
     if (sidebar) {
-      // Save opened checkboxes
-      localStorage.setItem("checkboxes",
-        JSON.stringify(
-          Array.from(
-            sidebar.querySelectorAll("input[type=checkbox]")
-          ).filter(input => input.checked).map(input => input.id)
-        )
-      )
-
-      // Save scroll postion
       localStorage.setItem("scroll", sidebar.scrollTop)
     }
   })
-
-  const storedCheckboxes = localStorage.getItem("checkboxes")
-  if (storedCheckboxes) {
-    JSON.parse(storedCheckboxes).forEach(id => {
-      document.getElementById(id).checked = true
-    })
-  }
 
   const storedScrollPosition = localStorage.getItem("scroll")
   if (storedScrollPosition) {
@@ -61,7 +43,7 @@ function handleState() {
     localStorage.removeItem("scroll");
   }
 
-}
+})
 
 // Send GA events any time a code block is copied
 document.addEventListener("DOMContentLoaded", function() {
@@ -96,4 +78,3 @@ document.addEventListener("DOMContentLoaded", function() {
 window.addEventListener("scroll", loadVisibleTermynals);
 createTermynals();
 loadVisibleTermynals();
-handleState()


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes some issues with the sidebar that arose from caching the HTML for the sidebar. In short, I had issues getting the JS to store the checkbox state to work. I solved this in python, by reusing the cached toctree HTML but setting the "checked" state on the appropriate dropdown inputs on each page using `beautifulsoup`. The operation comes with an overhead, but it's still quite small compared to reconstructing a new toctree every page write.

## Related issue number

Partially addressed https://github.com/ray-project/ray/issues/37944.
Targets https://github.com/ray-project/ray/pull/41115.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
