### PR TITLE
[Doc] Final cleanup

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -128,8 +128,7 @@ compile_pip_dependencies() {
     "${WORKSPACE_DIR}/python/requirements/ml/train-requirements.txt" \
     "${WORKSPACE_DIR}/python/requirements/ml/train-test-requirements.txt" \
     "${WORKSPACE_DIR}/python/requirements/ml/tune-requirements.txt" \
-    "${WORKSPACE_DIR}/python/requirements/ml/tune-test-requirements.txt" \
-    "${WORKSPACE_DIR}/doc/requirements-doc.txt"
+    "${WORKSPACE_DIR}/python/requirements/ml/tune-test-requirements.txt"
 
   # Remove some pins from upstream dependencies:
   # ray, xgboost-ray, lightgbm-ray, tune-sklearn

--- a/ci/docker/doc.build.Dockerfile
+++ b/ci/docker/doc.build.Dockerfile
@@ -12,11 +12,4 @@ SHELL ["/bin/bash", "-ice"]
 COPY . .
 
 RUN pip install -U --ignore-installed  \
-  -c python/requirements_compiled.txt \
-  -r python/requirements.txt \
-  -r python/requirements/test-requirements.txt \
-  -r python/requirements/lint-requirements.txt \
-  -r doc/requirements-doc.txt 
-
-RUN HOROVOD_WITH_GLOO=1 HOROVOD_WITHOUT_MPI=1 HOROVOD_WITHOUT_MXNET=1 \
-  pip install -U --ignore-installed  -c python/requirements_compiled.txt horovod
+  -r doc/requirements-doc.txt

--- a/ci/docker/doc.build.wanda.yaml
+++ b/ci/docker/doc.build.wanda.yaml
@@ -2,10 +2,6 @@ name: "docbuild"
 froms: ["cr.ray.io/rayproject/oss-ci-base_build"]
 dockerfile: ci/docker/doc.build.Dockerfile
 srcs:
-  - python/requirements.txt
-  - python/requirements_compiled.txt
-  - python/requirements/test-requirements.txt
-  - python/requirements/lint-requirements.txt
   - doc/requirements-doc.txt
 tags:
   - cr.ray.io/rayproject/docbuild

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,6 +1,5 @@
 # Production requirements. This is what readthedocs.com picks up
 
-git+https://github.com/ray-project/tune-sklearn@master#tune-sklearn
 watchfiles==0.19.0 # Required because sphinx-click doesn't support mocking
 
 # Syntax highlighting

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -463,11 +463,15 @@ autosummary_filename_map = {
 # Mock out external dependencies here.
 autodoc_mock_imports = [
     "aiohttp",
+    "aiosignal",
     "composer",
     "dask",
     "datasets",
     "fastapi",
+    "filelock",
+    "frozenlist",
     "fsspec",
+    "google",
     "grpc",
     "gymnasium",
     "horovod",


### PR DESCRIPTION
## Why are these changes needed?

This PR removes `tune-sklearn` as a dependency (it's no longer needed to build docs in `master`). This was pulling in a lot of transitive dependencies (including ray!), and a few needed to be mocked out to make the docs build.

## Related issue number

Partially addresses https://github.com/ray-project/ray/issues/37944.
Targets https://github.com/ray-project/ray/pull/41115.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a 
           method in Tune, I've added it in `doc/source/tune/api/` under the 
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
